### PR TITLE
Pac 5.1

### DIFF
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -48,7 +48,7 @@
 
 #include "RenderEngine/RenderEngine.h"
 #ifdef QCOM_BSP
-#include <gralloc_priv.h>
+#include <../../../../hardware/qcom/display-caf/libgralloc/gralloc_priv.h>
 #endif
 
 #define DEBUG_RESIZE    0

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -84,7 +84,7 @@
 #include "RenderEngine/RenderEngine.h"
 #include <cutils/compiler.h>
 #ifdef QCOM_BSP
-#include <gralloc_priv.h>
+#include <../../../../hardware/qcom/display-caf/libgralloc/gralloc_priv.h>
 #endif
 
 #ifdef QCOM_BSP

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -88,7 +88,7 @@
 #endif
 
 #ifdef QCOM_BSP
-#include <display_config.h>
+#include <../../../../hardware/qcom/display-caf/libqdutils/display_config.h>
 #endif
 
 #define DISPLAY_COUNT       1


### PR DESCRIPTION
This change let fix build error with non exist gralloc_priv.h file. Which file is exist in hardware/qcom/display-caf/libgralloc. 
